### PR TITLE
Fix pagination and add secure upload utilities

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { validateFile, saveFile, sanitizeFilename } from '@/utils/fileUpload';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const complaintId = formData.get('complaintId') as string | null;
+    const files = formData.getAll('files') as File[];
+
+    if (!complaintId || files.length === 0) {
+      return NextResponse.json(
+        { error: 'ข้อมูลไม่ถูกต้อง' },
+        { status: 400 }
+      );
+    }
+
+    const complaint = await prisma.complaint.findUnique({
+      where: { id: complaintId }
+    });
+    if (!complaint) {
+      return NextResponse.json(
+        { error: 'ไม่พบข้อร้องเรียน' },
+        { status: 404 }
+      );
+    }
+
+    const uploaded: any[] = [];
+
+    for (const file of files) {
+      if (file.size === 0) continue;
+      const validation = validateFile(file);
+      if (!validation.isValid) {
+        return NextResponse.json(
+          { error: validation.error },
+          { status: 400 }
+        );
+      }
+
+      const url = await saveFile(file, complaintId);
+      const attachment = await prisma.attachment.create({
+        data: {
+          filename: sanitizeFilename(file.name),
+          url,
+          fileSize: file.size,
+          fileType: file.type,
+          complaintId
+        }
+      });
+      uploaded.push(attachment);
+    }
+
+    return NextResponse.json({ success: true, attachments: uploaded });
+  } catch (error) {
+    console.error('Error uploading files:', error);
+    return NextResponse.json(
+      { error: 'เกิดข้อผิดพลาดในการอัปโหลดไฟล์' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/complaints/page.tsx
+++ b/app/dashboard/complaints/page.tsx
@@ -311,8 +311,8 @@ export default function ComplaintsPage() {
       if (response.ok) {
         const data = await response.json();
         setComplaints(data.complaints || []);
-        setTotalPages(Math.ceil((data.total || 0) / itemsPerPage));
-        setTotalCount(data.total || 0);
+        setTotalPages(Math.ceil((data.pagination?.totalCount || 0) / itemsPerPage));
+        setTotalCount(data.pagination?.totalCount || 0);
       }
     } catch (error) {
       console.error('Error fetching complaints:', error);

--- a/app/dashboard/complaints/page_enhanced.tsx
+++ b/app/dashboard/complaints/page_enhanced.tsx
@@ -221,8 +221,8 @@ export default function ComplaintsPage() {
       if (response.ok) {
         const data = await response.json();
         setComplaints(data.complaints || []);
-        setTotalPages(Math.ceil((data.total || 0) / itemsPerPage));
-        setTotalCount(data.total || 0);
+        setTotalPages(Math.ceil((data.pagination?.totalCount || 0) / itemsPerPage));
+        setTotalCount(data.pagination?.totalCount || 0);
       }
     } catch (error) {
       console.error('Error fetching complaints:', error);

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,56 @@
+import React, { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: (error: Error) => ReactNode;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: any) {
+    console.error('Error Boundary caught an error:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback && this.state.error) {
+        return this.props.fallback(this.state.error);
+      }
+
+      return (
+        <div className="flex items-center justify-center min-h-[200px] p-8">
+          <div className="text-center">
+            <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-2">เกิดข้อผิดพลาด</h3>
+            <p className="text-gray-600 mb-4">ขออภัย เกิดข้อผิดพลาดในการแสดงผล</p>
+            <button
+              onClick={() => window.location.reload()}
+              className="bg-primary text-white px-4 py-2 rounded-lg hover:bg-primary/90"
+            >
+              รีโหลดหน้า
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,12 @@ model Complaint {
   createdAt   DateTime   @default(now())
   updatedAt   DateTime   @updatedAt
 
+  @@index([status])
+  @@index([category])
+  @@index([priority])
+  @@index([createdAt])
+  @@index([status, category])
+  @@index([status, priority])
   @@map("complaints")
 }
 
@@ -35,6 +41,7 @@ model Attachment {
   complaint   Complaint @relation(fields: [complaintId], references: [id], onDelete: Cascade)
   createdAt   DateTime  @default(now())
 
+  @@index([complaintId])
   @@map("attachments")
 }
 
@@ -48,6 +55,8 @@ model User {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
 
+  @@index([role])
+  @@index([isActive])
   @@map("users")
 }
 
@@ -59,6 +68,8 @@ model Notification {
   read      Boolean  @default(false)
   createdAt DateTime @default(now())
 
+  @@index([read])
+  @@index([createdAt])
   @@map("notifications")
 }
 

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,0 +1,94 @@
+export interface ApiResponse<T = any> {
+  success?: boolean;
+  error?: string;
+  message?: string;
+  data?: T;
+}
+
+export interface PaginationResponse<T> {
+  data: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    totalCount: number;
+    totalPages: number;
+    hasNext: boolean;
+    hasPrev: boolean;
+  };
+}
+
+export interface AttachmentResponse {
+  id: string;
+  filename: string;
+  url: string;
+  fileSize: number;
+  fileType: string;
+  createdAt: string;
+}
+
+export interface ComplaintResponse {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  priority: string;
+  status: string;
+  trackingId: string;
+  createdAt: string;
+  updatedAt?: string;
+  attachments: AttachmentResponse[];
+}
+
+export interface DashboardStats {
+  totalComplaints: number;
+  newComplaints: number;
+  inProgressComplaints: number;
+  resolvedComplaints: number;
+  closedComplaints: number;
+  archivedComplaints: number;
+  avgResponseTime: number;
+  todayComplaints: number;
+  categoryBreakdown: Array<{
+    category: string;
+    count: number;
+  }>;
+  priorityBreakdown: Array<{
+    priority: string;
+    count: number;
+  }>;
+  monthlyTrends: Record<string, number>;
+}
+
+export interface NotificationResponse {
+  id: string;
+  title: string;
+  message: string;
+  type: 'info' | 'success' | 'warning' | 'error';
+  read: boolean;
+  createdAt: string;
+}
+
+export interface ComplaintFilters {
+  search?: string;
+  status?: string;
+  category?: string;
+  priority?: string;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+  page?: number;
+  limit?: number;
+}
+
+export interface CreateComplaintRequest {
+  title: string;
+  description: string;
+  category: string;
+  priority: string;
+  files?: File[];
+}
+
+export interface UpdateComplaintRequest {
+  status?: string;
+  priority?: string;
+  category?: string;
+}

--- a/utils/fileUpload.ts
+++ b/utils/fileUpload.ts
@@ -1,0 +1,90 @@
+import { writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/pdf',
+  'text/plain',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+];
+
+const ALLOWED_EXTENSIONS = [
+  '.jpg', '.jpeg', '.png', '.gif',
+  '.pdf', '.txt', '.doc', '.docx'
+];
+
+export interface FileValidationResult {
+  isValid: boolean;
+  error?: string;
+}
+
+export function validateFile(file: File): FileValidationResult {
+  if (file.size > MAX_FILE_SIZE) {
+    return {
+      isValid: false,
+      error: `ไฟล์ ${file.name} มีขนาดใหญ่เกินไป (สูงสุด 5MB)`
+    };
+  }
+
+  if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+    return {
+      isValid: false,
+      error: `ไฟล์ ${file.name} ประเภทไม่รองรับ`
+    };
+  }
+
+  const extension = file.name.toLowerCase().substring(file.name.lastIndexOf('.'));
+  if (!ALLOWED_EXTENSIONS.includes(extension)) {
+    return {
+      isValid: false,
+      error: `นามสกุลไฟล์ ${extension} ไม่รองรับ`
+    };
+  }
+
+  const suspiciousPatterns = [
+    /\.exe$/i, /\.bat$/i, /\.cmd$/i, /\.scr$/i,
+    /\.php$/i, /\.jsp$/i, /\.asp$/i, /\.js$/i
+  ];
+
+  if (suspiciousPatterns.some(pattern => pattern.test(file.name))) {
+    return {
+      isValid: false,
+      error: `ไฟล์ ${file.name} อาจเป็นอันตราย`
+    };
+  }
+
+  return { isValid: true };
+}
+
+export async function saveFile(file: File, complaintId: string): Promise<string> {
+  const uploadDir = join(process.cwd(), 'public', 'uploads');
+
+  if (!existsSync(uploadDir)) {
+    await mkdir(uploadDir, { recursive: true });
+  }
+
+  const timestamp = Date.now();
+  const randomStr = Math.random().toString(36).substring(2, 8);
+  const extension = file.name.substring(file.name.lastIndexOf('.'));
+  const safeFilename = `${complaintId}-${timestamp}-${randomStr}${extension}`;
+
+  const filepath = join(uploadDir, safeFilename);
+  const bytes = await file.arrayBuffer();
+  const buffer = Buffer.from(bytes);
+
+  await writeFile(filepath, buffer);
+
+  return `/uploads/${safeFilename}`;
+}
+
+export function sanitizeFilename(filename: string): string {
+  return filename
+    .replace(/[^a-zA-Z0-9.-]/g, '_')
+    .replace(/_{2,}/g, '_')
+    .toLowerCase();
+}


### PR DESCRIPTION
## Summary
- update complaints pages to use `pagination.totalCount`
- implement `POST /api/upload` with validation and saving
- add `fileUpload` util and `ErrorBoundary` component
- define API types
- add helpful indexes to Prisma schema

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861fb029840832880a22fcafc518cf6