### PR TITLE
Implement rate limiting & admin page fixes

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -10,7 +10,7 @@ npm install
 ### 2. ตั้งค่าฐานข้อมูล
 สร้างฐานข้อมูล MySQL และแก้ไข `.env` file:
 ```
-DATABASE_URL="mysql://username:password@localhost:3306/complaintdb"
+DATABASE_URL="mysql://root@localhost:3307/complaintdbv2"
 NEXTAUTH_SECRET="your-secret-key"
 NEXTAUTH_URL="http://localhost:3000"
 ```

--- a/app/api/attachments/[id]/route.ts
+++ b/app/api/attachments/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const attachment = await prisma.attachment.findUnique({
+      where: { id: params.id },
+    });
+
+    if (!attachment) {
+      return NextResponse.json({ error: 'ไม่พบไฟล์' }, { status: 404 });
+    }
+
+    const filePath = join(process.cwd(), 'public', attachment.url.replace(/^\//, ''));
+    const fileBuffer = await readFile(filePath);
+
+    return new Response(fileBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': attachment.fileType,
+        'Content-Disposition': `attachment; filename="${attachment.filename}"`,
+      },
+    });
+  } catch (error) {
+    console.error('Error downloading file:', error);
+    return NextResponse.json({ error: 'เกิดข้อผิดพลาดในการดาวน์โหลดไฟล์' }, { status: 500 });
+  }
+}

--- a/app/dashboard/complaints/page.tsx
+++ b/app/dashboard/complaints/page.tsx
@@ -1,19 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { CategoryBadge } from "@/components/ui/CategoryBadge";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
-import { 
+import {
   Search,
   Filter,
   Calendar,
   FileText,
   Eye,
-  Edit,
   ChevronLeft,
   ChevronRight,
   RefreshCw,
@@ -29,10 +28,13 @@ import {
   Paperclip,
   X,
   User,
-  ExternalLink
+  ExternalLink,
+  AlertCircle
 } from "lucide-react";
 import { formatDate, getPriorityColor, getStatusColor, getPriorityLabel, getStatusLabel } from "@/lib/utils";
 import { STATUS_LEVELS, PRIORITY_LEVELS, COMPLAINT_CATEGORIES } from "@/lib/constants";
+import { ErrorBoundary } from "@/utils/fileUpload";
+import { toast } from "sonner";
 
 interface Complaint {
   id: string;
@@ -47,15 +49,8 @@ interface Complaint {
   attachments: Array<{
     id: string;
     filename: string;
-    url: string;
-    fileSize: number;
     fileType: string;
-  }>;
-  responses?: Array<{
-    id: string;
-    message: string;
-    createdAt: string;
-    isAdmin: boolean;
+    fileSize: number;
   }>;
 }
 
@@ -68,7 +63,23 @@ interface FilterState {
   sortOrder: 'asc' | 'desc';
 }
 
-// Loading Skeleton Component
+interface ApiResponse {
+  success: boolean;
+  data?: {
+    complaints: Complaint[];
+    pagination: {
+      page: number;
+      limit: number;
+      totalCount: number;
+      totalPages: number;
+      hasNext: boolean;
+      hasPrev: boolean;
+    };
+    filters: FilterState;
+  };
+  error?: string;
+}
+
 function LoadingSkeleton() {
   return (
     <div className="space-y-4 animate-pulse">
@@ -79,7 +90,6 @@ function LoadingSkeleton() {
   );
 }
 
-// Empty State Component
 function EmptyState() {
   return (
     <div className="text-center py-16">
@@ -96,13 +106,31 @@ function EmptyState() {
   );
 }
 
-// Complaint Detail Modal Component
-function ComplaintDetailModal({ 
-  complaint, 
-  onClose, 
-  onUpdateStatus 
-}: { 
-  complaint: Complaint | null; 
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="text-center py-16">
+      <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+        <AlertCircle className="w-8 h-8 text-red-600" />
+      </div>
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        เกิดข้อผิดพลาด
+      </h3>
+      <p className="text-gray-500 dark:text-gray-400 mb-4">
+        {message}
+      </p>
+      <Button onClick={onRetry} variant="outline">
+        ลองใหม่
+      </Button>
+    </div>
+  );
+}
+
+function ComplaintDetailModal({
+  complaint,
+  onClose,
+  onUpdateStatus
+}: {
+  complaint: Complaint | null;
   onClose: () => void;
   onUpdateStatus: (id: string, status: string) => void;
 }) {
@@ -138,7 +166,6 @@ function ComplaintDetailModal({
         </CardHeader>
         
         <CardContent className="flex-1 overflow-y-auto p-6 space-y-6">
-          {/* Status and Category Info */}
           <div className="grid md:grid-cols-4 gap-4">
             <div className="space-y-2">
               <p className="text-sm font-medium text-gray-600 dark:text-gray-400">ประเภท</p>
@@ -181,7 +208,6 @@ function ComplaintDetailModal({
             </div>
           </div>
 
-          {/* Description */}
           <div className="space-y-3">
             <p className="text-sm font-medium text-gray-600 dark:text-gray-400">รายละเอียด</p>
             <div className="bg-gray-50 dark:bg-gray-800 p-4 rounded-lg border">
@@ -191,7 +217,6 @@ function ComplaintDetailModal({
             </div>
           </div>
 
-          {/* Attachments */}
           {complaint.attachments.length > 0 && (
             <div className="space-y-3">
               <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
@@ -215,7 +240,7 @@ function ComplaintDetailModal({
                     </div>
                     <Button variant="outline" size="sm" asChild>
                       <a
-                        href={attachment.url}
+                        href={`/api/attachments/${attachment.id}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center space-x-2"
@@ -230,39 +255,6 @@ function ComplaintDetailModal({
               </div>
             </div>
           )}
-
-          {/* Responses/Comments */}
-          {complaint.responses && complaint.responses.length > 0 && (
-            <div className="space-y-3">
-              <p className="text-sm font-medium text-gray-600 dark:text-gray-400">
-                การตอบกลับ ({complaint.responses.length})
-              </p>
-              <div className="space-y-3">
-                {complaint.responses.map((response) => (
-                  <div key={response.id} className={`p-4 rounded-lg border ${
-                    response.isAdmin 
-                      ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' 
-                      : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700'
-                  }`}>
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center space-x-2">
-                        <User className="w-4 h-4 text-gray-500" />
-                        <span className="text-sm font-medium">
-                          {response.isAdmin ? 'ผู้ดูแลระบบ' : 'ผู้ส่งเรื่อง'}
-                        </span>
-                      </div>
-                      <span className="text-xs text-gray-500">
-                        {formatDate(new Date(response.createdAt))}
-                      </span>
-                    </div>
-                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-line">
-                      {response.message}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
         </CardContent>
       </Card>
     </div>
@@ -272,6 +264,7 @@ function ComplaintDetailModal({
 export default function ComplaintsPage() {
   const [complaints, setComplaints] = useState<Complaint[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [totalCount, setTotalCount] = useState(0);
@@ -289,12 +282,10 @@ export default function ComplaintsPage() {
 
   const itemsPerPage = 10;
 
-  useEffect(() => {
-    fetchComplaints();
-  }, [currentPage, filters]);
-
-  const fetchComplaints = async () => {
+  const fetchComplaints = useCallback(async () => {
     if (!refreshing) setLoading(true);
+    setError(null);
+    
     try {
       const params = new URLSearchParams({
         page: currentPage.toString(),
@@ -308,19 +299,34 @@ export default function ComplaintsPage() {
       });
 
       const response = await fetch(`/api/admin/complaints?${params}`);
-      if (response.ok) {
-        const data = await response.json();
-        setComplaints(data.complaints || []);
-        setTotalPages(Math.ceil((data.pagination?.totalCount || 0) / itemsPerPage));
-        setTotalCount(data.pagination?.totalCount || 0);
+      const data: ApiResponse = await response.json();
+      
+      if (!response.ok) {
+        throw new Error(data.error || 'เกิดข้อผิดพลาดในการดึงข้อมูล');
       }
+
+      if (data.success && data.data) {
+        setComplaints(data.data.complaints);
+        setTotalPages(data.data.pagination.totalPages);
+        setTotalCount(data.data.pagination.totalCount);
+      } else {
+        throw new Error(data.error || 'ข้อมูลไม่ถูกต้อง');
+      }
+      
     } catch (error) {
       console.error('Error fetching complaints:', error);
+      const errorMessage = error instanceof Error ? error.message : 'เกิดข้อผิดพลาดในการดึงข้อมูล';
+      setError(errorMessage);
+      toast.error(errorMessage);
     } finally {
       setLoading(false);
       setRefreshing(false);
     }
-  };
+  }, [currentPage, filters, refreshing]);
+
+  useEffect(() => {
+    fetchComplaints();
+  }, [fetchComplaints]);
 
   const updateComplaintStatus = async (id: string, newStatus: string) => {
     try {
@@ -333,14 +339,19 @@ export default function ComplaintsPage() {
       });
 
       if (response.ok) {
+        toast.success('อัพเดทสถานะเรียบร้อยแล้ว');
         fetchComplaints();
-        // Update selected complaint if it's open
         if (selectedComplaint?.id === id) {
           setSelectedComplaint(prev => prev ? { ...prev, status: newStatus } : null);
         }
+      } else {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'เกิดข้อผิดพลาดในการอัพเดท');
       }
     } catch (error) {
       console.error('Error updating complaint status:', error);
+      const errorMessage = error instanceof Error ? error.message : 'เกิดข้อผิดพลาดในการอัพเดท';
+      toast.error(errorMessage);
     }
   };
 
@@ -389,334 +400,333 @@ export default function ComplaintsPage() {
     );
   }
 
+  if (error) {
+    return (
+      <div className="p-4 md:p-8 max-w-7xl mx-auto">
+        <ErrorState message={error} onRetry={fetchComplaints} />
+      </div>
+    );
+  }
+
   return (
-    <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-8">
-      {/* Header */}
-      <div className="space-y-4 animate-slide-in">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-              จัดการเรื่องร้องเรียน
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400 mt-2">
-              ดูและจัดการเรื่องร้องเรียนทั้งหมดในระบบ • {totalCount.toLocaleString()} รายการ
-            </p>
-          </div>
-          
-          <div className="flex items-center space-x-3">
-            <Button
-              onClick={handleRefresh}
-              disabled={refreshing}
-              variant="outline"
-              size="sm"
-            >
-              <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
-              รีเฟรช
-            </Button>
-            <Button variant="outline" size="sm">
-              <Download className="w-4 h-4 mr-2" />
-              ส่งออก
-            </Button>
+    <ErrorBoundary>
+      <div className="p-4 md:p-8 max-w-7xl mx-auto space-y-8">
+        <div className="space-y-4 animate-slide-in">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+                จัดการเรื่องร้องเรียน
+              </h1>
+              <p className="text-gray-600 dark:text-gray-400 mt-2">
+                ดูและจัดการเรื่องร้องเรียนทั้งหมดในระบบ • {totalCount.toLocaleString()} รายการ
+              </p>
+            </div>
+            
+            <div className="flex items-center space-x-3">
+              <Button
+                onClick={handleRefresh}
+                disabled={refreshing}
+                variant="outline"
+                size="sm"
+              >
+                <RefreshCw className={`w-4 h-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
+                รีเฟรช
+              </Button>
+              <Button variant="outline" size="sm">
+                <Download className="w-4 h-4 mr-2" />
+                ส่งออก
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Filters */}
-      <Card className="hover-lift">
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            <div className="flex items-center space-x-2">
-              <Filter className="w-5 h-5" />
-              <span>ตัวกรองและค้นหา</span>
-            </div>
-            {(filters.search || filters.status !== 'all' || filters.category !== 'all' || filters.priority !== 'all') && (
-              <Button
-                onClick={clearFilters}
-                variant="ghost"
-                size="sm"
-                className="text-gray-500 hover:text-gray-700"
-              >
-                ล้างตัวกรอง
-              </Button>
-            )}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
-            {/* Search */}
-            <div className="lg:col-span-2 relative">
-              <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-              <Input
-                placeholder="ค้นหาเรื่องร้องเรียน..."
-                value={filters.search}
-                onChange={(e) => handleFilterChange('search', e.target.value)}
-                className="pl-10 input-modern"
-              />
-            </div>
-
-            {/* Status Filter */}
-            <Select value={filters.status} onValueChange={(value) => handleFilterChange('status', value)}>
-              <SelectTrigger>
-                <SelectValue placeholder="สถานะ" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">สถานะทั้งหมด</SelectItem>
-                {STATUS_LEVELS.map((status) => (
-                  <SelectItem key={status.value} value={status.value}>
-                    <div className="flex items-center space-x-2">
-                      {status.value === 'NEW' && <AlertTriangle className="w-4 h-4 text-orange-500" />}
-                      {status.value === 'IN_PROGRESS' && <Clock className="w-4 h-4 text-yellow-500" />}
-                      {status.value === 'RESOLVED' && <CheckCircle className="w-4 h-4 text-green-500" />}
-                      <span>{status.label}</span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            {/* Category Filter */}
-            <Select value={filters.category} onValueChange={(value) => handleFilterChange('category', value)}>
-              <SelectTrigger>
-                <SelectValue placeholder="ประเภท" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">ประเภททั้งหมด</SelectItem>
-                {COMPLAINT_CATEGORIES.map((category) => (
-                  <SelectItem key={category.value} value={category.value}>
-                    <div className="flex items-center space-x-2">
-                      <category.icon className="w-4 h-4" />
-                      <span>{category.label}</span>
-                    </div>
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            {/* Priority Filter */}
-            <Select value={filters.priority} onValueChange={(value) => handleFilterChange('priority', value)}>
-              <SelectTrigger>
-                <SelectValue placeholder="ความสำคัญ" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">ความสำคัญทั้งหมด</SelectItem>
-                {PRIORITY_LEVELS.map((priority) => (
-                  <SelectItem key={priority.value} value={priority.value}>
-                    {priority.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Complaints Table */}
-      <Card className="hover-lift">
-        <CardHeader>
-          <CardTitle>
-            รายการเรื่องร้องเรียน ({complaints.length.toLocaleString()} รายการ)
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {complaints.length === 0 ? (
-            <EmptyState />
-          ) : (
-            <>
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-gray-200 dark:border-gray-700">
-                      <th 
-                        className="text-left p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                        onClick={() => handleSort('trackingId')}
-                      >
-                        <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
-                          <Hash className="w-4 h-4" />
-                          <span>รหัสติดตาม</span>
-                          {filters.sortBy === 'trackingId' && (
-                            filters.sortOrder === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />
-                          )}
-                        </div>
-                      </th>
-                      <th 
-                        className="text-left p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                        onClick={() => handleSort('title')}
-                      >
-                        <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
-                          <MessageSquare className="w-4 h-4" />
-                          <span>หัวข้อ</span>
-                          {filters.sortBy === 'title' && (
-                            filters.sortOrder === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />
-                          )}
-                        </div>
-                      </th>
-                      <th className="text-left p-3">
-                        <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
-                          <Tag className="w-4 h-4" />
-                          <span>ประเภท</span>
-                        </div>
-                      </th>
-                      <th className="text-left p-3 text-sm font-medium text-gray-600 dark:text-gray-400">ความสำคัญ</th>
-                      <th className="text-left p-3 text-sm font-medium text-gray-600 dark:text-gray-400">สถานะ</th>
-                      <th 
-                        className="text-left p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                        onClick={() => handleSort('createdAt')}
-                      >
-                        <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
-                          <Calendar className="w-4 h-4" />
-                          <span>วันที่ส่ง</span>
-                          {filters.sortBy === 'createdAt' && (
-                            filters.sortOrder === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />
-                          )}
-                        </div>
-                      </th>
-                      <th className="text-left p-3 text-sm font-medium text-gray-600 dark:text-gray-400">การจัดการ</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {complaints.map((complaint, index) => (
-                      <tr 
-                        key={complaint.id}
-                        className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors animate-slide-in"
-                        style={{ animationDelay: `${index * 0.05}s` }}
-                      >
-                        <td className="p-3 font-mono text-sm">
-                          <Badge variant="outline" className="font-medium">
-                            {complaint.trackingId}
-                          </Badge>
-                        </td>
-                        <td className="p-3">
-                          <div className="max-w-xs">
-                            <p className="font-medium text-gray-900 dark:text-white truncate">
-                              {complaint.title}
-                            </p>
-                            <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
-                              {complaint.description}
-                            </p>
-                          </div>
-                        </td>
-                        <td className="p-3">
-                          <CategoryBadge category={complaint.category} />
-                        </td>
-                        <td className="p-3">
-                          <Badge className={getPriorityColor(complaint.priority)}>
-                            {getPriorityLabel(complaint.priority)}
-                          </Badge>
-                        </td>
-                        <td className="p-3">
-                          <Select
-                            value={complaint.status}
-                            onValueChange={(value) => updateComplaintStatus(complaint.id, value)}
-                          >
-                            <SelectTrigger className={`w-36 ${getStatusColor(complaint.status)}`}>
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {STATUS_LEVELS.map((status) => (
-                                <SelectItem key={status.value} value={status.value}>
-                                  <div className="flex items-center space-x-2">
-                                    {status.value === 'NEW' && <AlertTriangle className="w-4 h-4" />}
-                                    {status.value === 'IN_PROGRESS' && <Clock className="w-4 h-4" />}
-                                    {status.value === 'RESOLVED' && <CheckCircle className="w-4 h-4" />}
-                                    <span>{status.label}</span>
-                                  </div>
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </td>
-                        <td className="p-3">
-                          <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
-                            <Calendar className="w-4 h-4 mr-1" />
-                            {formatDate(new Date(complaint.createdAt))}
-                          </div>
-                        </td>
-                        <td className="p-3">
-                          <div className="flex items-center space-x-2">
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => setSelectedComplaint(complaint)}
-                              className="hover-lift"
-                            >
-                              <Eye className="w-4 h-4 mr-1" />
-                              ดู
-                            </Button>
-                            {complaint.attachments.length > 0 && (
-                              <Badge variant="secondary" className="text-xs">
-                                <Paperclip className="w-3 h-3 mr-1" />
-                                {complaint.attachments.length}
-                              </Badge>
-                            )}
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+        <Card className="hover-lift">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <div className="flex items-center space-x-2">
+                <Filter className="w-5 h-5" />
+                <span>ตัวกรองและค้นหา</span>
+              </div>
+              {(filters.search || filters.status !== 'all' || filters.category !== 'all' || filters.priority !== 'all') && (
+                <Button
+                  onClick={clearFilters}
+                  variant="ghost"
+                  size="sm"
+                  className="text-gray-500 hover:text-gray-700"
+                >
+                  ล้างตัวกรอง
+                </Button>
+              )}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+              <div className="lg:col-span-2 relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                <Input
+                  placeholder="ค้นหาเรื่องร้องเรียน..."
+                  value={filters.search}
+                  onChange={(e) => handleFilterChange('search', e.target.value)}
+                  className="pl-10 input-modern"
+                />
               </div>
 
-              {/* Pagination */}
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    หน้า {currentPage} จาก {totalPages} • แสดง {complaints.length} จาก {totalCount.toLocaleString()} รายการ
-                  </p>
-                  <div className="flex items-center space-x-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
-                      disabled={currentPage === 1}
-                      className="hover-lift"
-                    >
-                      <ChevronLeft className="w-4 h-4 mr-1" />
-                      ก่อนหน้า
-                    </Button>
-                    
-                    {/* Page numbers */}
-                    <div className="hidden sm:flex items-center space-x-1">
-                      {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-                        const pageNumber = Math.max(1, Math.min(totalPages, currentPage - 2 + i));
-                        return (
-                          <Button
-                            key={pageNumber}
-                            variant={currentPage === pageNumber ? "default" : "outline"}
-                            size="sm"
-                            onClick={() => setCurrentPage(pageNumber)}
-                            className="w-8 h-8 p-0"
-                          >
-                            {pageNumber}
-                          </Button>
-                        );
-                      })}
-                    </div>
-                    
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
-                      disabled={currentPage === totalPages}
-                      className="hover-lift"
-                    >
-                      ถัดไป
-                      <ChevronRight className="w-4 h-4 ml-1" />
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </>
-          )}
-        </CardContent>
-      </Card>
+              <Select value={filters.status} onValueChange={(value) => handleFilterChange('status', value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="สถานะ" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">สถานะทั้งหมด</SelectItem>
+                  {STATUS_LEVELS.map((status) => (
+                    <SelectItem key={status.value} value={status.value}>
+                      <div className="flex items-center space-x-2">
+                        {status.value === 'NEW' && <AlertTriangle className="w-4 h-4 text-orange-500" />}
+                        {status.value === 'IN_PROGRESS' && <Clock className="w-4 h-4 text-yellow-500" />}
+                        {status.value === 'RESOLVED' && <CheckCircle className="w-4 h-4 text-green-500" />}
+                        <span>{status.label}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
 
-      {/* Complaint Detail Modal */}
-      <ComplaintDetailModal
-        complaint={selectedComplaint}
-        onClose={() => setSelectedComplaint(null)}
-        onUpdateStatus={updateComplaintStatus}
-      />
-    </div>
+              <Select value={filters.category} onValueChange={(value) => handleFilterChange('category', value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="ประเภท" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">ประเภททั้งหมด</SelectItem>
+                  {COMPLAINT_CATEGORIES.map((category) => (
+                    <SelectItem key={category.value} value={category.value}>
+                      <div className="flex items-center space-x-2">
+                        <category.icon className="w-4 h-4" />
+                        <span>{category.label}</span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select value={filters.priority} onValueChange={(value) => handleFilterChange('priority', value)}>
+                <SelectTrigger>
+                  <SelectValue placeholder="ความสำคัญ" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">ความสำคัญทั้งหมด</SelectItem>
+                  {PRIORITY_LEVELS.map((priority) => (
+                    <SelectItem key={priority.value} value={priority.value}>
+                      {priority.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="hover-lift">
+          <CardHeader>
+            <CardTitle>
+              รายการเรื่องร้องเรียน ({complaints.length.toLocaleString()} รายการ)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {complaints.length === 0 ? (
+              <EmptyState />
+            ) : (
+              <>
+                <div className="overflow-x-auto">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-gray-200 dark:border-gray-700">
+                        <th 
+                          className="text-left p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                          onClick={() => handleSort('trackingId')}
+                        >
+                          <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+                            <Hash className="w-4 h-4" />
+                            <span>รหัสติดตาม</span>
+                            {filters.sortBy === 'trackingId' && (
+                              filters.sortOrder === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />
+                            )}
+                          </div>
+                        </th>
+                        <th 
+                          className="text-left p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                          onClick={() => handleSort('title')}
+                        >
+                          <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+                            <MessageSquare className="w-4 h-4" />
+                            <span>หัวข้อ</span>
+                            {filters.sortBy === 'title' && (
+                              filters.sortOrder === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />
+                            )}
+                          </div>
+                        </th>
+                        <th className="text-left p-3">
+                          <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+                            <Tag className="w-4 h-4" />
+                            <span>ประเภท</span>
+                          </div>
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium text-gray-600 dark:text-gray-400">ความสำคัญ</th>
+                        <th className="text-left p-3 text-sm font-medium text-gray-600 dark:text-gray-400">สถานะ</th>
+                        <th 
+                          className="text-left p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                          onClick={() => handleSort('createdAt')}
+                        >
+                          <div className="flex items-center space-x-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+                            <Calendar className="w-4 h-4" />
+                            <span>วันที่ส่ง</span>
+                            {filters.sortBy === 'createdAt' && (
+                              filters.sortOrder === 'asc' ? <SortAsc className="w-4 h-4" /> : <SortDesc className="w-4 h-4" />
+                            )}
+                          </div>
+                        </th>
+                        <th className="text-left p-3 text-sm font-medium text-gray-600 dark:text-gray-400">การจัดการ</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {complaints.map((complaint, index) => (
+                        <tr 
+                          key={complaint.id}
+                          className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors animate-slide-in"
+                          style={{ animationDelay: `${index * 0.05}s` }}
+                        >
+                          <td className="p-3 font-mono text-sm">
+                            <Badge variant="outline" className="font-medium">
+                              {complaint.trackingId}
+                            </Badge>
+                          </td>
+                          <td className="p-3">
+                            <div className="max-w-xs">
+                              <p className="font-medium text-gray-900 dark:text-white truncate">
+                                {complaint.title}
+                              </p>
+                              <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                                {complaint.description}
+                              </p>
+                            </div>
+                          </td>
+                          <td className="p-3">
+                            <CategoryBadge category={complaint.category} />
+                          </td>
+                          <td className="p-3">
+                            <Badge className={getPriorityColor(complaint.priority)}>
+                              {getPriorityLabel(complaint.priority)}
+                            </Badge>
+                          </td>
+                          <td className="p-3">
+                            <Select
+                              value={complaint.status}
+                              onValueChange={(value) => updateComplaintStatus(complaint.id, value)}
+                            >
+                              <SelectTrigger className={`w-36 ${getStatusColor(complaint.status)}`}>
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {STATUS_LEVELS.map((status) => (
+                                  <SelectItem key={status.value} value={status.value}>
+                                    <div className="flex items-center space-x-2">
+                                      {status.value === 'NEW' && <AlertTriangle className="w-4 h-4" />}
+                                      {status.value === 'IN_PROGRESS' && <Clock className="w-4 h-4" />}
+                                      {status.value === 'RESOLVED' && <CheckCircle className="w-4 h-4" />}
+                                      <span>{status.label}</span>
+                                    </div>
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </td>
+                          <td className="p-3">
+                            <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+                              <Calendar className="w-4 h-4 mr-1" />
+                              {formatDate(new Date(complaint.createdAt))}
+                            </div>
+                          </td>
+                          <td className="p-3">
+                            <div className="flex items-center space-x-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setSelectedComplaint(complaint)}
+                                className="hover-lift"
+                              >
+                                <Eye className="w-4 h-4 mr-1" />
+                                ดู
+                              </Button>
+                              {complaint.attachments.length > 0 && (
+                                <Badge variant="secondary" className="text-xs">
+                                  <Paperclip className="w-3 h-3 mr-1" />
+                                  {complaint.attachments.length}
+                                </Badge>
+                              )}
+                            </div>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {totalPages > 1 && (
+                  <div className="flex items-center justify-between mt-6 pt-6 border-t border-gray-200 dark:border-gray-700">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      หน้า {currentPage} จาก {totalPages} • แสดง {complaints.length} จาก {totalCount.toLocaleString()} รายการ
+                    </p>
+                    <div className="flex items-center space-x-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setCurrentPage(prev => Math.max(1, prev - 1))}
+                        disabled={currentPage === 1}
+                        className="hover-lift"
+                      >
+                        <ChevronLeft className="w-4 h-4 mr-1" />
+                        ก่อนหน้า
+                      </Button>
+                      
+                      <div className="hidden sm:flex items-center space-x-1">
+                        {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                          const pageNumber = Math.max(1, Math.min(totalPages, currentPage - 2 + i));
+                          return (
+                            <Button
+                              key={pageNumber}
+                              variant={currentPage === pageNumber ? "default" : "outline"}
+                              size="sm"
+                              onClick={() => setCurrentPage(pageNumber)}
+                              className="w-8 h-8 p-0"
+                            >
+                              {pageNumber}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                      
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setCurrentPage(prev => Math.min(totalPages, prev + 1))}
+                        disabled={currentPage === totalPages}
+                        className="hover-lift"
+                      >
+                        ถัดไป
+                        <ChevronRight className="w-4 h-4 ml-1" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <ComplaintDetailModal
+          complaint={selectedComplaint}
+          onClose={() => setSelectedComplaint(null)}
+          onUpdateStatus={updateComplaintStatus}
+        />
+      </div>
+    </ErrorBoundary>
   );
 }
-

--- a/lib/rateLimiting.ts
+++ b/lib/rateLimiting.ts
@@ -1,0 +1,157 @@
+interface RateLimitConfig {
+  windowMs: number;
+  maxRequests: number;
+}
+
+class RateLimiter {
+  private requests: Map<string, number[]> = new Map();
+  private config: RateLimitConfig;
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+  }
+
+  isAllowed(identifier: string): boolean {
+    const now = Date.now();
+    const userRequests = this.requests.get(identifier) || [];
+    const validRequests = userRequests.filter(
+      timestamp => now - timestamp < this.config.windowMs
+    );
+
+    if (validRequests.length >= this.config.maxRequests) {
+      return false;
+    }
+
+    validRequests.push(now);
+    this.requests.set(identifier, validRequests);
+    return true;
+  }
+
+  getRemainingRequests(identifier: string): number {
+    const userRequests = this.requests.get(identifier) || [];
+    const now = Date.now();
+    const validRequests = userRequests.filter(
+      timestamp => now - timestamp < this.config.windowMs
+    );
+
+    return Math.max(0, this.config.maxRequests - validRequests.length);
+  }
+}
+
+export const publicApiLimiter = new RateLimiter({
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 50,
+});
+
+export const authApiLimiter = new RateLimiter({
+  windowMs: 5 * 60 * 1000,
+  maxRequests: 5,
+});
+
+export const fileUploadLimiter = new RateLimiter({
+  windowMs: 60 * 60 * 1000,
+  maxRequests: 10,
+});
+
+export function getClientIP(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  const realIP = request.headers.get('x-real-ip');
+
+  if (forwarded) {
+    return forwarded.split(',')[0].trim();
+  }
+  if (realIP) {
+    return realIP;
+  }
+  return 'unknown';
+}
+
+export function createErrorResponse(message: string, status: number = 400) {
+  return new Response(
+    JSON.stringify({ success: false, error: message }),
+    {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+}
+
+export function createSuccessResponse(data: any, message?: string) {
+  return new Response(
+    JSON.stringify({ success: true, data, ...(message && { message }) }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+}
+
+export function validateEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+export function validateTrackingId(trackingId: string): boolean {
+  const trackingIdRegex = /^TRK-[A-Z0-9]+-[A-Z0-9]+$/;
+  return trackingIdRegex.test(trackingId);
+}
+
+export function sanitizeSearchQuery(query: string): string {
+  return query.replace(/[<>"'%;()&+]/g, '').trim().substring(0, 100);
+}
+
+export async function executeWithRetry<T>(operation: () => Promise<T>, maxRetries: number = 3): Promise<T> {
+  let lastError: Error;
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error as Error;
+      console.error(`Operation failed (attempt ${i + 1}/${maxRetries}):`, error);
+      if (i < maxRetries - 1) {
+        await new Promise(resolve => setTimeout(resolve, Math.pow(2, i) * 1000));
+      }
+    }
+  }
+  throw lastError!;
+}
+
+import { z } from 'zod';
+
+export const TrackingQuerySchema = z.object({
+  trackingId: z.string().min(1, 'กรุณาระบุรหัสติดตาม').regex(/^TRK-[A-Z0-9]+-[A-Z0-9]+$/, 'รหัสติดตามไม่ถูกต้อง'),
+});
+
+export const ComplaintQuerySchema = z.object({
+  page: z.string().regex(/^\d+$/).transform(Number).optional().default(1),
+  limit: z.string().regex(/^\d+$/).transform(Number).optional().default(10),
+  search: z.string().max(100).optional(),
+  status: z.enum(['NEW', 'IN_PROGRESS', 'RESOLVED', 'CLOSED', 'ARCHIVED']).optional(),
+  category: z.enum([
+    'TECHNICAL',
+    'PERSONNEL',
+    'ENVIRONMENT',
+    'EQUIPMENT',
+    'SAFETY',
+    'FINANCIAL',
+    'STRUCTURE_SYSTEM',
+    'WELFARE_SERVICES',
+    'PROJECT_IDEA',
+    'OTHER',
+  ]).optional(),
+  priority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'URGENT']).optional(),
+  sortBy: z.enum(['createdAt', 'updatedAt', 'priority', 'status', 'title']).optional().default('createdAt'),
+  sortOrder: z.enum(['asc', 'desc']).optional().default('desc'),
+});
+
+export function withRateLimit(limiter: RateLimiter) {
+  return function (handler: Function) {
+    return async function (request: Request, ...args: any[]) {
+      const clientIP = getClientIP(request);
+      if (!limiter.isAllowed(clientIP)) {
+        return createErrorResponse('Too many requests. Please try again later.', 429);
+      }
+      return handler(request, ...args);
+    };
+  };
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/api/:path*',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'X-XSS-Protection', value: '1; mode=block' },
+        ],
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "./node_modules/.bin/tsc lib/stores/notification.ts --module commonjs --target ES2017 --outDir build/lib && node --test",
     "db:push": "prisma db push",
-    "db:seed": "node scripts/seed.js"
+    "db:seed": "node scripts/seed.js",
+    "postinstall": "mkdir -p public/uploads"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",


### PR DESCRIPTION
## Summary
- add comprehensive rate limiting helpers
- enhance admin complaints API with validation & retries
- overhaul complaints dashboard page with error handling
- secure file download API for attachments
- set security headers in Next config
- sync database url in SETUP.md
- create uploads folder after install

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861fda971808328a96dfb93b647b287