### PR TITLE
Open attachments without downloading

### DIFF
--- a/app/dashboard/complaints/page_enhanced.tsx
+++ b/app/dashboard/complaints/page_enhanced.tsx
@@ -164,8 +164,16 @@ function ComplaintDetailModal({
                     <div key={attachment.id} className="flex items-center space-x-3 p-3 border rounded-lg">
                       <Paperclip className="w-4 h-4" />
                       <span className="flex-1">{attachment.filename}</span>
-                      <Button size="sm" variant="outline">
-                        ดาวน์โหลด
+                      <Button size="sm" variant="outline" asChild>
+                        <a
+                          href={attachment.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center space-x-1"
+                        >
+                          <Eye className="w-4 h-4" />
+                          <span>เปิดไฟล์</span>
+                        </a>
                       </Button>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
- allow viewing complaint attachment files directly in a new browser tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686202bed9cc83288f54534f8a47ccc2