### PR TITLE
Implement styled login/logout buttons

### DIFF
--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -5,7 +5,7 @@ import { signIn, getSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { LoginButton } from "@/components/ui/auth-buttons";
 import { MessageCircle, AlertCircle } from "lucide-react";
 import { toast } from "sonner";
 
@@ -106,9 +106,12 @@ export default function SignInPage() {
                 </div>
               )}
 
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? "กำลังเข้าสู่ระบบ..." : "เข้าสู่ระบบ"}
-              </Button>
+              <LoginButton
+                type="submit"
+                className="mx-auto"
+                loading={loading}
+                disabled={loading}
+              />
             </form>
           </CardContent>
         </Card>

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -6,13 +6,12 @@ import {
   Home, 
   MessageSquare, 
   BarChart3, 
-  Settings, 
-  LogOut,
+  Settings,
   MessageCircle,
   Bell
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import { LogoutButton } from "@/components/ui/auth-buttons";
 import { useNotificationStore } from "@/lib/stores/notification";
 
 const navigation = [
@@ -109,14 +108,7 @@ export function Sidebar() {
 
       {/* Sign Out */}
       <div className="p-4 border-t">
-        <Button
-          onClick={handleSignOut}
-          variant="ghost"
-          className="w-full justify-start text-gray-700 hover:bg-gray-100"
-        >
-          <LogOut className="w-5 h-5 mr-3" />
-          ออกจากระบบ
-        </Button>
+        <LogoutButton onClick={handleSignOut} className="mx-auto" />
       </div>
     </div>
   );

--- a/components/ui/auth-buttons.tsx
+++ b/components/ui/auth-buttons.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { LogIn, LogOut } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ExpandButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  label: string;
+  icon: React.ReactNode;
+  colorClass?: string;
+}
+
+const ExpandButton = React.forwardRef<HTMLButtonElement, ExpandButtonProps>(
+  ({ label, icon, colorClass = "bg-red-500", className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          "group relative flex items-center justify-start overflow-hidden rounded-full w-12 h-12 transition-all duration-300 shadow-md",
+          colorClass,
+          className
+        )}
+        {...props}
+      >
+        <span className="flex items-center justify-center w-full transition-all duration-300 group-hover:w-[30%] group-hover:pl-4">
+          {icon}
+        </span>
+        <span className="absolute right-0 opacity-0 w-0 text-white text-sm font-semibold transition-all duration-300 group-hover:w-[70%] group-hover:opacity-100 group-hover:pr-3">
+          {label}
+        </span>
+      </button>
+    );
+  }
+);
+ExpandButton.displayName = "ExpandButton";
+
+interface LoginButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+}
+
+export const LoginButton = React.forwardRef<HTMLButtonElement, LoginButtonProps>(
+  ({ loading, className, ...props }, ref) => (
+    <ExpandButton
+      ref={ref}
+      label={loading ? "\u0e01\u0e33\u0e25\u0e31\u0e07\u0e40\u0e02\u0e49\u0e32\u0e2a\u0e39\u0e48\u0e23\u0e30\u0e1a\u0e1a..." : "\u0e40\u0e02\u0e49\u0e32\u0e2a\u0e39\u0e48\u0e23\u0e30\u0e1a\u0e1a"}
+      icon={<LogIn className="w-4 h-4" />}
+      colorClass="bg-green-500"
+      className={className}
+      {...props}
+    />
+  )
+);
+LoginButton.displayName = "LoginButton";
+
+export const LogoutButton = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ className, ...props }, ref) => (
+    <ExpandButton
+      ref={ref}
+      label="\u0e2d\u0e2d\u0e01\u0e08\u0e32\u0e01\u0e23\u0e30\u0e1a\u0e1a"
+      icon={<LogOut className="w-4 h-4" />}
+      colorClass="bg-red-500"
+      className={className}
+      {...props}
+    />
+  )
+);
+LogoutButton.displayName = "LogoutButton";
+
+export { ExpandButton };


### PR DESCRIPTION
## Summary
- add expandable login/logout button components
- use the new `LoginButton` on the sign-in page
- use the new `LogoutButton` in the dashboard sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68620cf6d9988328afa459cc7daf7b14