### PR TITLE
Fix search bug and adjust success icon

### DIFF
--- a/app/tracking/page.tsx
+++ b/app/tracking/page.tsx
@@ -241,7 +241,7 @@ export default function TrackingPage() {
                 </div>
               </div>
               <Button
-                onClick={handleSearch}
+                onClick={() => handleSearch()}
                 disabled={loading || !trackingId.trim()}
                 className="btn-primary tap-target sm:px-8"
               >

--- a/components/form/ComplaintForm.tsx
+++ b/components/form/ComplaintForm.tsx
@@ -266,7 +266,7 @@ export default function ComplaintForm() {
         <CardContent className="p-6 sm:p-8">
           <div className="text-center space-y-6">
             {/* Success Icon */}
-            <div className="w-20 h-20 bg-gradient-primary rounded-full flex items-center justify-center mx-auto shadow-large animate-bounce-gentle">
+            <div className="w-20 h-20 bg-gradient-success desktop:bg-gradient-primary rounded-full flex items-center justify-center mx-auto shadow-large animate-bounce-gentle">
               <CheckCircle className="w-10 h-10 text-white" />
             </div>
             


### PR DESCRIPTION
## Summary
- prevent event object from corrupting tracking search
- make desktop success icon use primary red gradient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68624a01bde48328bd05be69d50a1ebc