### PR TITLE
Fix mobile menu overlap

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -145,7 +145,7 @@ export default function DashboardLayout({
           </div>
         </header>
 
-        <main className="flex-1 min-h-0 safe-bottom">
+        <main className="flex-1 min-h-0 pb-24 lg:pb-0 safe-bottom">
           <div className="h-full">
             {children}
           </div>


### PR DESCRIPTION
## Summary
- add extra bottom padding in dashboard layout to avoid overlap with fixed mobile navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686362e6332c832885303151cd74e9e0