### PR TITLE
Add timeRange filter for category analytics

### DIFF
--- a/app/dashboard/statistics/page.tsx
+++ b/app/dashboard/statistics/page.tsx
@@ -88,8 +88,9 @@ export default function StatisticsPage() {
 
   const fetchCategoryAnalytics = async () => {
     try {
+      setLoading(true);
       setRefreshing(true);
-      const response = await fetch('/api/admin/analytics/categories');
+      const response = await fetch(`/api/admin/analytics/categories?timeRange=${timeRange}`);
       if (!response.ok) {
         throw new Error('Failed to fetch category analytics');
       }


### PR DESCRIPTION
## Summary
- send `timeRange` query when fetching dashboard statistics
- reset loading state while loading analytics
- filter category analytics API by requested time range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863742b9cb08328871071db77a49d2c