### PR TITLE
Add display name helpers to utils

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -42,6 +42,7 @@ import {
   BarChart,
   Bar,
 } from "@/components/dashboard/Recharts";
+import { getCategoryDisplayName, getPriorityDisplayName } from "@/lib/utils";
 
 interface DashboardStats {
   totalComplaints: number;
@@ -218,32 +219,6 @@ export default function DashboardPage() {
 
   // Chart colors
   const COLORS = ['#ab1616', '#3b82f6', '#10b981', '#f59e0b', '#8b5cf6', '#ef4444', '#06b6d4'];
-
-  function getCategoryDisplayName(category: string) {
-    const categoryMap: Record<string, string> = {
-      'TECHNICAL': 'เทคนิค',
-      'PERSONNEL': 'บุคคล',
-      'ENVIRONMENT': 'สภาพแวดล้อม',
-      'EQUIPMENT': 'อุปกรณ์',
-      'SAFETY': 'ความปลอดภัย',
-      'FINANCIAL': 'การเงิน',
-      'STRUCTURE_SYSTEM': 'โครงสร้าง',
-      'WELFARE_SERVICES': 'สวัสดิการ',
-      'PROJECT_IDEA': 'ไอเดีย',
-      'OTHER': 'อื่นๆ'
-    };
-    return categoryMap[category] || category;
-  }
-
-  function getPriorityDisplayName(priority: string) {
-    const priorityMap: Record<string, string> = {
-      'LOW': 'ต่ำ',
-      'MEDIUM': 'ปานกลาง',
-      'HIGH': 'สูง',
-      'URGENT': 'เร่งด่วน'
-    };
-    return priorityMap[priority] || priority;
-  }
 
   if (loading) {
     return (

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -46,3 +46,29 @@ export function getStatusLabel(status: string): string {
   const statusData = STATUS_LEVELS.find(s => s.value === status);
   return statusData?.label || status;
 }
+
+export function getCategoryDisplayName(category: string): string {
+  const categoryMap: Record<string, string> = {
+    TECHNICAL: 'เทคนิค',
+    PERSONNEL: 'บุคคล',
+    ENVIRONMENT: 'สภาพแวดล้อม',
+    EQUIPMENT: 'อุปกรณ์',
+    SAFETY: 'ความปลอดภัย',
+    FINANCIAL: 'การเงิน',
+    STRUCTURE_SYSTEM: 'โครงสร้าง',
+    WELFARE_SERVICES: 'สวัสดิการ',
+    PROJECT_IDEA: 'ไอเดีย',
+    OTHER: 'อื่นๆ'
+  };
+  return categoryMap[category] || category;
+}
+
+export function getPriorityDisplayName(priority: string): string {
+  const priorityMap: Record<string, string> = {
+    LOW: 'ต่ำ',
+    MEDIUM: 'ปานกลาง',
+    HIGH: 'สูง',
+    URGENT: 'เร่งด่วน'
+  };
+  return priorityMap[priority] || priority;
+}


### PR DESCRIPTION
## Summary
- add `getCategoryDisplayName` and `getPriorityDisplayName` helpers in `lib/utils`
- use these helpers in `app/dashboard/page.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686374632eac8328b3e7f05e3e2b663e