### PR TITLE
Fix swr hook for dashboard

### DIFF
--- a/components/dashboard/ChartContainer.tsx
+++ b/components/dashboard/ChartContainer.tsx
@@ -3,8 +3,8 @@ import { ChartSkeleton } from './ChartSkeleton';
 import { ReactNode } from 'react';
 
 interface ChartContainerProps {
-  title: string;
-  description?: string;
+  title: ReactNode;
+  description?: ReactNode;
   loading?: boolean;
   children: ReactNode;
 }

--- a/components/dashboard/useAnalyticsData.ts
+++ b/components/dashboard/useAnalyticsData.ts
@@ -1,4 +1,6 @@
-import useSWR from 'swr';
+"use client";
+
+import useSWR from "swr";
 
 export interface DashboardStats {
   overallStats: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "sanitize-html": "^2.17.0",
         "sharp": "^0.34.2",
         "sonner": "^2.0.5",
-        "swr": "^1.3.0",
+        "swr": "^2.3.3",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.25.67",
@@ -8697,12 +8697,16 @@
       "license": "ISC"
     },
     "node_modules/swr": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
-      "integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
       "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
       "peerDependencies": {
-        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "sanitize-html": "^2.17.0",
     "sharp": "^0.34.2",
     "sonner": "^2.0.5",
-    "swr": "^1.3.0",
+    "swr": "^2.3.3",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.25.67",


### PR DESCRIPTION
## Summary
- make `useAnalyticsData` a client hook
- allow `ChartContainer` title and description to use `ReactNode`
- bump `swr` to v2.x

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68638e5ca76c832885c8bedfa646a96f