### PR TITLE
Fix Sidebar pathname type

### DIFF
--- a/app/dashboard/complaints/page.tsx
+++ b/app/dashboard/complaints/page.tsx
@@ -98,7 +98,7 @@ export default function ComplaintsPage() {
   }, [viewMode]);
 
   useEffect(() => {
-    const id = searchParams.get('view');
+    const id = searchParams?.get('view');
     if (id) {
       openComplaintById(id);
     }

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -56,7 +56,7 @@ interface SidebarProps {
 
 export function Sidebar({ isMobile = false, isOpen = false, onClose }: SidebarProps) {
   const { data: session } = useSession();
-  const pathname = usePathname();
+  const pathname = usePathname() ?? "";
 
   const handleSignOut = () => {
     signOut({ callbackUrl: "/" });


### PR DESCRIPTION
## Summary
- fix Sidebar to handle possible null from `usePathname`
- handle optional search params in Complaints page

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6864d7989a1c8328854d5b7c3f764468