### PR TITLE
Fix missing ajv-errors dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/multer": "^1.4.13",
         "@types/sanitize-html": "^2.16.0",
         "ajv": "^8.17.1",
+        "ajv-errors": "^3.0.0",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3290,6 +3291,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-errors": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
+      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.1"
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/multer": "^1.4.13",
     "@types/sanitize-html": "^2.16.0",
     "ajv": "^8.17.1",
+    "ajv-errors": "^3.0.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- install `ajv-errors`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864dda171608328853c37e67c57b5a5