### PR TITLE
Fix TypeScript build with backup node_modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "node_modules.bak"]
 }


### PR DESCRIPTION
## Summary
- avoid compiling `node_modules.bak` by excluding it in tsconfig

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864e14f4ca483288d8331b43c763584